### PR TITLE
Validate date of birth

### DIFF
--- a/lib/nailinda/accounts/patient.ex
+++ b/lib/nailinda/accounts/patient.ex
@@ -29,5 +29,20 @@ defmodule Nailinda.Accounts.Patient do
       :location
     ])
     |> validate_required([:first_name, :last_name, :date_of_birth])
+    |> _validate_date_is_not_future
+  end
+
+  defp _validate_date_is_not_future(changeset) do
+    input_date = get_field(changeset, :date_of_birth)
+
+    if input_date do
+      case Date.compare(Date.utc_today(), input_date) do
+        :lt -> add_error(changeset, :date_of_birth, "cannot be a future date")
+        :gt -> changeset
+        :eq -> changeset
+      end
+    else
+      changeset
+    end
   end
 end

--- a/test/nailinda/user/user_test.exs
+++ b/test/nailinda/user/user_test.exs
@@ -35,6 +35,13 @@ defmodule Nailinda.UserTest do
       assert patient.next_of_kin == "wayua"
     end
 
+    test "does not create patient with future date " do
+      future_date = Date.add(Date.utc_today(), +1)
+
+      assert {:error, _} =
+               Accounts.create_patient(Map.replace!(@valid_attrs, :date_of_birth, future_date))
+    end
+
     test "create user with invalid data to return a error" do
       assert {:error, %Ecto.Changeset{}} = Accounts.create_patient(@invalid_attrs)
     end


### PR DESCRIPTION
# Fixes issue number
fixes #127 

# Describe the changes made on this PR
- add a validation, date-of-birth can be same date or past date only
-
-
-

# Visuals
If your merge request had visual changes we need the screenshot of the affected pages and if behaviour changed
we will need a gif showing the new features

## Screenshots
<img width="965" alt="Screenshot 2019-04-01 21 53 43" src="https://user-images.githubusercontent.com/3761745/55349694-ff556880-54d7-11e9-9b65-d667bd4f37ef.png">

### Mobile view

Attach screenshot of changes as they appear on a small screen

### Desktop view
Attach screenshot of the changes as they appear on larger screens


## GIF
If there were changes on how the application behaves then attach a gif showing the new changes


# Reviews
- [x] I have formated by code as expected
We have a handy tool that helps you check if your elixir code is well formatted. If the tool passes on your local build
then it will definitly pass our linting checks online

- [x] I have filled in all the required information above
- [x] I have marked my work as `ready for review`
